### PR TITLE
BuddyPress.org provision tweaks

### DIFF
--- a/buddypressorg.dev/provision/vvv-init.sh
+++ b/buddypressorg.dev/provision/vvv-init.sh
@@ -3,7 +3,7 @@ SITE_DOMAIN="buddypressorg.dev"
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
 PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"
 SITE_DIR="$BASE_DIR/$SITE_DOMAIN/public_html"
-WPCLI_PLUGINS="akismet bbpress-no-admin syntaxhighlighter"
+WPCLI_PLUGINS="akismet bbpress-no-admin camptix email-post-changes syntaxhighlighter"
 
 source $BASE_DIR/helper-functions.sh
 wme_create_logs "$BASE_DIR/$SITE_DOMAIN/logs"

--- a/buddypressorg.dev/provision/vvv-init.sh
+++ b/buddypressorg.dev/provision/vvv-init.sh
@@ -3,7 +3,7 @@ SITE_DOMAIN="buddypressorg.dev"
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
 PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"
 SITE_DIR="$BASE_DIR/$SITE_DOMAIN/public_html"
-WPCLI_PLUGINS="akismet bbpress bbpress-no-admin buddypress camptix email-post-changes syntaxhighlighter"
+WPCLI_PLUGINS="akismet bbpress-no-admin syntaxhighlighter"
 
 source $BASE_DIR/helper-functions.sh
 wme_create_logs "$BASE_DIR/$SITE_DOMAIN/logs"
@@ -17,8 +17,16 @@ if [ ! -d $SITE_DIR ]; then
 	wp core download --path=$SITE_DIR/wordpress --allow-root
 	cp $PROVISION_DIR/wp-config.php $SITE_DIR
 
-	# BuddyPress.org
+	# bb-base theme
 	svn co https://meta.svn.wordpress.org/sites/trunk/buddypress.org/public_html/wp-content/ $SITE_DIR/wp-content
+
+	# BuddyPress /trunk
+	svn co https://plugins.svn.wordpress.org/buddypress/trunk $SITE_DIR/wp-content/plugins/buddypress
+
+	#bbPress /trunk
+	svn co https://plugins.svn.wordpress.org/bbpress/trunk $SITE_DIR/wp-content/plugins/bbpress
+
+	# Other plugins
 	wp plugin install $WPCLI_PLUGINS --path=$SITE_DIR/wordpress --allow-root
 
 	# Extra env. set up.
@@ -31,5 +39,7 @@ else
 	wp core   update --path=$SITE_DIR/wordpress --allow-root
 	wp plugin update --path=$SITE_DIR/wordpress --allow-root --all
 	svn up $SITE_DIR/wp-content
+	svn up $SITE_DIR/wp-content/plugins/buddypress
+	svn up $SITE_DIR/wp-content/plugins/bbpress
 
 fi


### PR DESCRIPTION
- Use BuddyPress /trunk from `https://plugins.svn.wordpress.org/buddypress/trunk`
- Use bbPress /trunk from `https://plugins.svn.wordpress.org/bbpress/trunk`
- Remove bbpress (see above),  buddypress (see above), camptix (unused), and email-post-changes (unused) plugins from WP-CLI plugin install list
